### PR TITLE
Reuse Hierarchy's markingClasses() method in SimplifyDataObjectDecorator

### DIFF
--- a/code/SimplifyDataObjectDecorator.php
+++ b/code/SimplifyDataObjectDecorator.php
@@ -78,16 +78,12 @@ class SimplifyDataObjectDecorator extends SiteTreeExtension {
 	 * 
 	 */
 	public function markingClasses() {
-		$classes = "";
-		
-		//Copy of markingClasses from Hierarchy.php (which extends DataObjectDecorator)
-		if(!$this->owner->isExpanded()) {
-			$classes .= " unexpanded";
-		}
-		if(!$this->owner->isTreeOpened()) {
-			$classes .= " closed";
-		}
-		
+		//Every DataObject has the Hierarchy extension attached to it,
+		//call its markingClasses() method first to determine $classes
+		$hierarchyExtension = $this->owner->getExtensionInstance('Hierarchy');
+		$hierarchyExtension->setOwner($this->owner);
+		$classes = $hierarchyExtension->markingClasses();
+
 		//Hide pages that have been selected in the top level of the Simplify fields tree -
 		//These will be where the field = page, ie; HidePage = HideName
 		$hideThisPage = DataObject::get("SimplifyPermission", 


### PR DESCRIPTION
SimplifyDataObjectDecorator's markingClasses() had code that was copied from
the Hierarchy extension's method of the same name. This caused trouble when
the original code changed as with SilverStripe 3.1.

Now instead of having to synchronize with Hierarchy with every major version,
we simply call its markingClasses() method first.

Note that simply calling $this->owner->markingClasses() caused segfaults for
me. The use of setOwner() on the returned Hierarchy instance is mandatory,
too, otherwise Hierarchy's other methods won't work correctly.
